### PR TITLE
Fix Windows 10 Console

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     })
     implementation("com.thoughtworks.paranamer:paranamer:2.8")
     implementation("ch.qos.logback:logback-classic:1.4.7")
+    implementation("net.java.dev.jna:jna:5.13.0")
+    implementation("net.java.dev.jna:jna-platform:5.13.0")
+
 }
 
 tasks.test {
@@ -37,6 +40,7 @@ tasks.withType(Jar::class) {
         attributes["Can-Retransform-Classes"] = true;
         attributes["Can-Redefine-Classes"] = true;
     }
+
 }
 
 tasks.withType<JavaCompile> { options.compilerArgs.add("-parameters") }

--- a/src/main/java/ru/artem/alaverdyan/PlusicInjector.java
+++ b/src/main/java/ru/artem/alaverdyan/PlusicInjector.java
@@ -48,6 +48,8 @@ public class PlusicInjector {
             }
         }
 
+        EConsole.enableAnsi();
+
         String outputDir = "output_classes";  // Директория для извлеченных классов
         String modifiedJarPath = "modifiedfile.jar"; // путь к модифицированному JAR файлу
 

--- a/src/main/java/ru/artem/alaverdyan/utilities/EConsole.java
+++ b/src/main/java/ru/artem/alaverdyan/utilities/EConsole.java
@@ -43,8 +43,6 @@ public class EConsole {
     private static final int DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
 
     public static void enableAnsi() {
-        WinDef.HWND hWnd = Kernel32.INSTANCE.GetConsoleWindow();
-
         int STD_OUTPUT_HANDLE = -11;
         WinNT.HANDLE hOut = Kernel32.INSTANCE.GetStdHandle(STD_OUTPUT_HANDLE);
 

--- a/src/main/java/ru/artem/alaverdyan/utilities/EConsole.java
+++ b/src/main/java/ru/artem/alaverdyan/utilities/EConsole.java
@@ -2,6 +2,11 @@ package ru.artem.alaverdyan.utilities;
 
 import java.util.ArrayList;
 
+import com.sun.jna.Native;
+import com.sun.jna.platform.win32.*;
+
+
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,7 +14,7 @@ public class EConsole {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EConsole.class);
 
-    
+
     // ANSI-коды для цветов и атрибутов
     public static final String RESET = "\u001B[0m";
     public static final String BLACK = "\u001B[30m";
@@ -33,6 +38,24 @@ public class EConsole {
 
     // Жирный текст
     public static final String BOLD = "\u001B[1m";
+
+    private static final int ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0001;
+    private static final int DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
+
+    public static void enableAnsi() {
+        WinDef.HWND hWnd = Kernel32.INSTANCE.GetConsoleWindow();
+
+        int STD_OUTPUT_HANDLE = -11;
+        WinNT.HANDLE hOut = Kernel32.INSTANCE.GetStdHandle(STD_OUTPUT_HANDLE);
+
+        int mode = ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
+
+        try {
+            Kernel32.INSTANCE.SetConsoleMode(hOut, mode);
+        } catch (RuntimeException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public static void write(String text) {
         System.out.println(text);


### PR DESCRIPTION
Фикс ANSI для консоли Windows 10. Работает не у всех, самый лучший способ просто переписать цвета под Jansi,но тогда придется либо каким то боком менять переменные, и за место ASI использовать цвета JANSI, в теории легко, а так хз. В следующем пуле попробую сделать.