### PR TITLE
Fix EConosle.write(String text)

### DIFF
--- a/src/main/java/ru/artem/alaverdyan/utilities/EConsole.java
+++ b/src/main/java/ru/artem/alaverdyan/utilities/EConsole.java
@@ -105,7 +105,7 @@ public class EConsole {
 
     public static void write(String text) {
         AnsiConsole.systemInstall();
-        System.out.println(text);
+        System.out.println(convert(text));
         AnsiConsole.systemUninstall();
 
     }


### PR DESCRIPTION
Добавил convert(text) для EConosle.write(String text) если будет использоваться ANSI в  EConosle.write(String text) 